### PR TITLE
Fix README and use `atom-package-deps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Ionide-FAKE
+# Ionide-Installer
 
 ## Contributing and copyright
 
-The project is hosted on [GitHub](https://github.com/ionide/ionide-fake) where you can [report issues](https://github.com/ionide/ionide-fake/issues), fork
+The project is hosted on [GitHub](https://github.com/ionide/ionide-installer) where you can [report issues](https://github.com/ionide/ionide-installer/issues), fork
 the project and submit pull requests.
 
-The library is available under [MIT license](https://github.com/ionide/ionide-fake/blob/master/LICENSE.md), which allows modification and
+The library is available under [MIT license](https://github.com/ionide/ionide-installer/blob/master/LICENSE.md), which allows modification and
 redistribution for both commercial and non-commercial purposes.
 
 ## Code of Conduct

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,8 +1,3 @@
-var apd = require('atom-package-dependencies');
-
-
 module.exports = IonideInstaller = {
-    activate: function(p1) {
-        apd.install();
-    }
+    activate: => require("atom-package-deps").install("ionide-installer")
 };

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
-    "atom-package-dependencies": "latest"
+    "atom-package-deps": "^2.1.3"
   },
-  "package-dependencies": {
-    "atom-yeoman": "",
-    "linter": "",
-    "advanced-open-file": "",
-    "ionide-fsharp": "",
-    "ionide-paket": "",
-    "ionide-fake": "",
-    "ionide-fsi": "",
-    "ionide-yeoman": ""
-  }
+  "package-depes": [
+    "atom-yeoman",
+    "linter",
+    "advanced-open-file",
+    "ionide-fsharp",
+    "ionide-paket",
+    "ionide-fake",
+    "ionide-fsi",
+    "ionide-yeoman"
+  ]
 }


### PR DESCRIPTION
`atom-package-deps` is being actively maintained by @steelbrain and is being used by the majority of currently maintained Linter packages.